### PR TITLE
Add "--jitter" option.

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -3,7 +3,13 @@
 
 typedef struct Config {
     long timeout;
+    long jitter;
     bool exclude_root;
     bool fork;
     bool debug;
 } Config;
+
+typedef struct coordinates_t {
+    int x;
+    int y;
+} coordinates_t;

--- a/man/unclutter-xfixes.man
+++ b/man/unclutter-xfixes.man
@@ -8,13 +8,16 @@ unclutter-xfixes - rewrite of unclutter using the X11-Xfixes extension
 
 == SYNOPSIS
 
-unclutter [--timeout <n>] [--exclude-root] [--fork|-b] [--help|-h] [--version|-v]
+unclutter [--timeout <n>] [--jitter <radius>] [--exclude-root] [--fork|-b] [--help|-h] [--version|-v]
 
 == OPTIONS
 
 --timeout <n>::
 Specifies the number of seconds after which the cursor should be hidden if
 it was neither moved nor any button was pressed. (Default: 5)
+
+--jitter <radius>::
+Ignore cursor movements if the cursor hasn't moved sufficiently far.
 
 --exclude-root::
 Don't hide the mouse cursor if it is idling over the root window and not an

--- a/src/unclutter.c
+++ b/src/unclutter.c
@@ -22,6 +22,7 @@ Display *display;
 
 Config config = {
     .timeout = 5,
+    .jitter = 0,
     .exclude_root = false,
     .fork = false,
     .debug = false
@@ -61,6 +62,7 @@ static void parse_args(int argc, char *argv[]) {
         opt_index = 0;
     static struct option long_options[] = {
         { "timeout", required_argument, 0, 0 },
+        { "jitter", required_argument, 0, 0 },
         { "exclude-root", no_argument, 0, 0 },
         { "fork", no_argument, 0, 'b' },
         { "version", no_argument, 0, 'v' },
@@ -68,7 +70,7 @@ static void parse_args(int argc, char *argv[]) {
         { 0, 0, 0, 0 }
     };
 
-    while ((c = getopt_long(argc, argv, "t:bvhd", long_options, &opt_index)) != -1) {
+    while ((c = getopt_long(argc, argv, "t:j:bvhd", long_options, &opt_index)) != -1) {
         long value;
 
         switch (c) {
@@ -79,6 +81,14 @@ static void parse_args(int argc, char *argv[]) {
                         ELOG("Invalid timeout specified.");
                     else
                         config.timeout = value;
+
+                    break;
+                } else if (strcmp(long_options[opt_index].name, "jitter") == 0) {
+                    value = parse_int(optarg);
+                    if (value < 0)
+                        ELOG("Invalid jitter value specified.");
+                    else
+                        config.jitter = value;
 
                     break;
                 } else if (strcmp(long_options[opt_index].name, "exclude-root") == 0) {
@@ -108,7 +118,7 @@ static void parse_args(int argc, char *argv[]) {
 }
 
 static void print_usage(char *argv[]) {
-    fprintf(stderr, "Usage: %s [--timeout <n>] [--exclude-root] [-b|--fork] [-v|--version] [-h|--help]", argv[0]);
+    fprintf(stderr, "Usage: %s [--timeout <n>] [--jitter <radius>] [--exclude-root] [-b|--fork] [-v|--version] [-h|--help]", argv[0]);
     fprintf(stderr, "\n");
     exit(EXIT_FAILURE);
 }


### PR DESCRIPTION
This option will disregard all cursor events in which the cursor
has not yet moved far enough from the last cursor position reported
by an event that has not been ignored.

fixes #7