### PR TITLE
Added new option --ignore-scrolling.

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -5,6 +5,7 @@ typedef struct Config {
     long timeout;
     long jitter;
     bool exclude_root;
+    bool ignore_scrolling;
     bool fork;
     bool debug;
 } Config;

--- a/man/unclutter-xfixes.man
+++ b/man/unclutter-xfixes.man
@@ -8,7 +8,7 @@ unclutter-xfixes - rewrite of unclutter using the X11-Xfixes extension
 
 == SYNOPSIS
 
-unclutter [--timeout <n>] [--jitter <radius>] [--exclude-root] [--fork|-b] [--help|-h] [--version|-v]
+unclutter [--timeout <n>] [--jitter <radius>] [--exclude-root] [--ignore-scrolling] [--fork|-b] [--help|-h] [--version|-v]
 
 == OPTIONS
 
@@ -23,6 +23,10 @@ Ignore cursor movements if the cursor hasn't moved sufficiently far.
 Don't hide the mouse cursor if it is idling over the root window and not an
 actual window since in this case it isn't obscuring anything important, but
 rather just the desktop background.
+
+--ignore-scrolling::
+Ignore mouse scroll events (buttons 4 and 5) so that scrolling doesn't unhide
+the cursor.
 
 --fork|-b::
 Fork unclutter to the background.

--- a/src/event.c
+++ b/src/event.c
@@ -56,7 +56,14 @@ static void x_check_cb(EV_P_ ev_check *w, int revents) {
             continue;
         }
 
-        /* We don't actually need the data, so get rid of it. */
+        if (config.ignore_scrolling && cookie->evtype == XI_RawButtonPress) {
+            const XIRawEvent *data = (const XIRawEvent *) cookie->data;
+            if (data->detail == 4 || data->detail == 5) {
+                XFreeEventData(display, cookie);
+                continue;
+            }
+        }
+
         XFreeEventData(display, cookie);
 
         if (config.jitter > 0 && cookie->evtype == XI_RawMotion) {

--- a/src/unclutter.c
+++ b/src/unclutter.c
@@ -24,6 +24,7 @@ Config config = {
     .timeout = 5,
     .jitter = 0,
     .exclude_root = false,
+    .ignore_scrolling = false,
     .fork = false,
     .debug = false
 };
@@ -64,6 +65,7 @@ static void parse_args(int argc, char *argv[]) {
         { "timeout", required_argument, 0, 0 },
         { "jitter", required_argument, 0, 0 },
         { "exclude-root", no_argument, 0, 0 },
+        { "ignore-scrolling", no_argument, 0, 0 },
         { "fork", no_argument, 0, 'b' },
         { "version", no_argument, 0, 'v' },
         { "help", no_argument, 0, 'h' },
@@ -94,6 +96,9 @@ static void parse_args(int argc, char *argv[]) {
                 } else if (strcmp(long_options[opt_index].name, "exclude-root") == 0) {
                     config.exclude_root = true;
                     break;
+                } else if (strcmp(long_options[opt_index].name, "ignore-scrolling") == 0) {
+                    config.ignore_scrolling = true;
+                    break;
                 }
 
                 print_usage(argv);
@@ -118,7 +123,7 @@ static void parse_args(int argc, char *argv[]) {
 }
 
 static void print_usage(char *argv[]) {
-    fprintf(stderr, "Usage: %s [--timeout <n>] [--jitter <radius>] [--exclude-root] [-b|--fork] [-v|--version] [-h|--help]", argv[0]);
+    fprintf(stderr, "Usage: %s [--timeout <n>] [--jitter <radius>] [--exclude-root] [--ignore-scrolling] [-b|--fork] [-v|--version] [-h|--help]", argv[0]);
     fprintf(stderr, "\n");
     exit(EXIT_FAILURE);
 }


### PR DESCRIPTION
When set, scroll events (buttons 4 and 5) are ignored for unhiding the
mouse cursor.

fixes #13