### PR TITLE
Establish compatibility with old unclutter.

### DIFF
--- a/man/unclutter-xfixes.man
+++ b/man/unclutter-xfixes.man
@@ -8,34 +8,71 @@ unclutter-xfixes - rewrite of unclutter using the X11-Xfixes extension
 
 == SYNOPSIS
 
-unclutter [--timeout <n>] [--jitter <radius>] [--exclude-root] [--ignore-scrolling] [--fork|-b] [--help|-h] [--version|-v]
+unclutter [*--timeout* _seconds_] [*--jitter* _radius_] [*--exclude-root*] [*--ignore-scrolling*] [*--fork*|*-b*] [*--help*|*-h*] [*--version*|*-v*]
+
+Compatibility arguments:
+
+unclutter [*--display*|*-d* _display_] [*--idle* _seconds_] [*--keystroke*] [*--grab*] [*--noevents*] [*--reset*] [*--root*] [*--onescreen*] [*--not*] _name …_
 
 == OPTIONS
 
---timeout <n>::
+*--timeout* _seconds_::
 Specifies the number of seconds after which the cursor should be hidden if
 it was neither moved nor any button was pressed. (Default: 5)
 
---jitter <radius>::
+*--jitter* _radius_::
 Ignore cursor movements if the cursor hasn't moved sufficiently far.
 
---exclude-root::
+*--exclude-root*::
 Don't hide the mouse cursor if it is idling over the root window and not an
 actual window since in this case it isn't obscuring anything important, but
 rather just the desktop background.
 
---ignore-scrolling::
+*--ignore-scrolling*::
 Ignore mouse scroll events (buttons 4 and 5) so that scrolling doesn't unhide
 the cursor.
 
---fork|-b::
+*--fork*|*-b*::
 Fork unclutter to the background.
 
---help|-h::
+*--help|-h*::
 Display the usage and exit.
 
---version|-v::
+*--version*|*-v*::
 Display the version and exit.
+
+== COMPATIBILITY
+
+In order to be used as a drop-in replacement of unclutter, unclutter-xfixes
+accepts all command line arguments of unclutter, but ignores most of them.
+
+*--display*|*-d* _display_::
+This argument is ignored.
+
+*--idle* _seconds_::
+This argument is mapped to *--timeout*.
+
+*--keystroke*::
+This argument is ignored.
+
+*--grab*::
+This argument is ignored.
+
+*--noevents*::
+This argument is ignored.
+
+*--reset*::
+This argument is ignored.
+
+*--root*::
+This argument is ignored as this is the default behavior in unclutter-xfixes.
+See *--exclude-root*.
+
+*--onescreen*::
+This argument is ignored.
+
+*--not*::
+This argument is ignored.
 
 == DESCRIPTION
 

--- a/man/unclutter-xfixes.man
+++ b/man/unclutter-xfixes.man
@@ -47,7 +47,8 @@ In order to be used as a drop-in replacement of unclutter, unclutter-xfixes
 accepts all command line arguments of unclutter, but ignores most of them.
 
 *--display*|*-d* _display_::
-This argument is ignored.
+Specifies the X display to use. The same effect can be achieved by setting the
+*DISPLAY* environment variable.
 
 *--idle* _seconds_::
 This argument is mapped to *--timeout*.

--- a/src/unclutter.c
+++ b/src/unclutter.c
@@ -93,7 +93,10 @@ static void parse_args(int argc, char *argv[]) {
 
         switch (c) {
             case 0:
-                if (OPT_NAME_IS("timeout") || OPT_NAME_IS("idle")) {
+                if (OPT_NAME_IS("display")) {
+                    setenv("DISPLAY", optarg, true);
+                    break;
+                } else if (OPT_NAME_IS("timeout") || OPT_NAME_IS("idle")) {
                     value = parse_int(optarg);
                     if (value < 0)
                         ELOG("Invalid timeout specified.");
@@ -118,7 +121,7 @@ static void parse_args(int argc, char *argv[]) {
                 } else if (OPT_NAME_IS("debug")) {
                     config.debug = true;
                     break;
-                } else if (OPT_NAME_IS("display") || OPT_NAME_IS("keystroke") || OPT_NAME_IS("grab") ||
+                } else if (OPT_NAME_IS("keystroke") || OPT_NAME_IS("grab") ||
                         OPT_NAME_IS("noevents") || OPT_NAME_IS("reset") || OPT_NAME_IS("root") ||
                         OPT_NAME_IS("onescreen") || OPT_NAME_IS("not")) {
                     ELOG("Using unsupported unclutter argument \"%s\", ignoring.", opt_name);
@@ -135,7 +138,7 @@ static void parse_args(int argc, char *argv[]) {
                 exit(EXIT_SUCCESS);
                 break;
             case 'd':
-                ELOG("Using unsupported unclutter argument \"d\", ignoring.");
+                setenv("DISPLAY", optarg, true);
                 break;
             case 'h':
             default:


### PR DESCRIPTION
This commit introduces compatibility with the original unclutter project
by allowing both all of its command-line parameters as well as the single
dash syntax for parameters.

fixes #14
