### PR TITLE
Makefile: add PKG_CONFIG variable.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,13 +11,14 @@ MANDIR = $(PREFIX)/share/man/man1
 
 CC = gcc
 LD = $(CC)
+PKG_CONFIG = pkg-config
 
 CPPFLAGS += -D'__VERSION="$(shell git describe --all --long --always)"' "-I$(IDIR)"
 
 CFLAGS += -std=gnu99
 CFLAGS += -Wall -Wundef -Wshadow -Wformat-security
 
-LDFLAGS += $(shell pkg-config --libs x11 xi xfixes)
+LDFLAGS += $(shell $(PKG_CONFIG) --libs x11 xi xfixes)
 # libev has no pkg-config support
 LDFLAGS += -lev
 


### PR DESCRIPTION
This makes it easier for distros like Exherbo that ___require___ that host-tools like pkg-config be prefixed with the arch they are being run from (example: x86_64-pc-linux-gnu-pkg-config )