### PR TITLE
Update Arch installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,13 @@ This is a rewrite of the popular tool unclutter, but using the x11-xfixes extens
 
 ## Installation
 
-### Arch / Manjaro (AUR)
+### Arch / Manjaro
 
-unclutter-xfixes is available in the AUR as [unclutter-xfixes-git](https://aur.archlinux.org/packages/unclutter-xfixes-git/).
+```
+pacman -S unclutter
+```
+
+unclutter-xfixes is also available in the AUR as [unclutter-xfixes-git](https://aur.archlinux.org/packages/unclutter-xfixes-git/).
 
 ### Fedora
 


### PR DESCRIPTION
Let's update the README 😉 

By the way, you can also remove `unclutter-xfixes` from `conflicts()` array now, such package doesn't exist anymore 😉 