### PR TITLE
clarify radius flag

### DIFF
--- a/man/unclutter-xfixes.man
+++ b/man/unclutter-xfixes.man
@@ -21,7 +21,7 @@ Specifies the number of seconds after which the cursor should be hidden if
 it was neither moved nor any button was pressed. (Default: 5)
 
 *--jitter* _radius_::
-Ignore cursor movements if the cursor hasn't moved sufficiently far.
+Ignore cursor movements if the cursor hasn't moved at least _radius_ pixels.
 
 *--exclude-root*::
 Don't hide the mouse cursor if it is idling over the root window and not an


### PR DESCRIPTION
Reading the man page, I was briefly confused about how `--jitter` was supposed to work. I thought it should be clarified.

I thought of adding an issue: "Please clarify this flag", but, although I'm not 100% sure this is how it works (I read a bit of the source & some Xlib man pages, but I could still be wrong), I imagine the maintainer knows immediately whether or not it's correct. If it is, merging this is easier than responding to an issue.