### PR TITLE
Changed timeout to support double values

### DIFF
--- a/include/externals.h
+++ b/include/externals.h
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <err.h>
 #include <ev.h>
+#include <float.h>
 
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>

--- a/include/types.h
+++ b/include/types.h
@@ -12,7 +12,7 @@ typedef struct ignore_buttons_t {
 } ignore_buttons_t;
 
 typedef struct Config {
-    long timeout;
+    double timeout;
     long jitter;
     bool exclude_root;
     bool ignore_scrolling;

--- a/include/util.h
+++ b/include/util.h
@@ -28,4 +28,6 @@ void bail(char *message);
 
 long int parse_int(char *str);
 
+double parse_double(char *str);
+
 void parse_buttons_numbers(char *str, ignore_buttons_t *ignore_buttons);

--- a/src/unclutter.c
+++ b/src/unclutter.c
@@ -107,6 +107,7 @@ static void parse_args(int argc, char *argv[]) {
 
     while ((c = getopt_long_only(argc, argv, "t:j:bvhd:", long_options, &opt_index)) != -1) {
         long value;
+        double value_double;
         const char *opt_name = long_options[opt_index].name;
 
 #define OPT_NAME_IS(name) (strcmp(opt_name, (name)) == 0)
@@ -117,11 +118,11 @@ static void parse_args(int argc, char *argv[]) {
                     setenv("DISPLAY", optarg, true);
                     break;
                 } else if (OPT_NAME_IS("timeout") || OPT_NAME_IS("idle")) {
-                    value = parse_int(optarg);
-                    if (value < 0)
+                    value_double = parse_double(optarg);
+                    if (value_double < 0)
                         ELOG("Invalid timeout specified.");
                     else
-                        config.timeout = value;
+                        config.timeout = value_double;
 
                     break;
                 } else if (OPT_NAME_IS("jitter")) {

--- a/src/util.c
+++ b/src/util.c
@@ -18,6 +18,18 @@ long parse_int(char *str) {
     return parsed;
 }
 
+double parse_double(char *str) {
+    char *endptr = NULL;
+    double parsed = strtod(str, &endptr);
+    if (parsed == -DBL_MAX || parsed == DBL_MAX ||
+            parsed < 0 || endptr == str) {
+
+        return -1;
+    }
+
+    return parsed;
+}
+
 void parse_buttons_numbers(char *str, ignore_buttons_t *ignore_buttons) {
     char *button = strtok(str, ",");
     while (button != NULL) {


### PR DESCRIPTION
Terribly sorry if I've asked about this before, but I just (re)discovered this change I made locally probably a couple of years ago. Couldn't find any previous issues or PRs related to this though, so here goes:

This simply enables you to use decimal numbers as the timeout, IE. 0.2 seconds, which is what I use on my machine. It's also compatible with integers, as 1 is simply read as 1.0 which works just fine. I haven't done too much coding in C, so feel free to butcher my implementation/formatting :slightly_smiling_face: 