### PR TITLE
fixes scrolling with trackpoint

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -47,7 +47,7 @@ static void x_cb(EV_P_ ev_io *w, int revents) {
 }
 
 static bool is_button_ignored(const XIRawEvent *data) {
-    if (config.ignore_scrolling && (data->detail == 4 || data->detail == 5)) {
+    if (config.ignore_scrolling && (data->detail == 4 || data->detail == 5 || data->detail == 6)) {
         return true;
     }
 


### PR DESCRIPTION
By scrolling "harder" with my thinkpad x230 trackpoint, using libinput drivers, it will report a button 6 event. Possibly is a bug with libinput, when i was using the synaptics drivers in arch i don't remember having this problem. example xev output:

```

ButtonRelease event, serial 32, synthetic NO, window 0x2000001,
    root 0x139, subw 0x0, time 15265257, (82,90), root:(673,382),
    state 0x800, button 4, same_screen YES

ButtonPress event, serial 32, synthetic NO, window 0x2000001,
    root 0x139, subw 0x0, time 15265257, (82,90), root:(673,382),
    state 0x0, button 4, same_screen YES

ButtonRelease event, serial 32, synthetic NO, window 0x2000001,
    root 0x139, subw 0x0, time 15265257, (82,90), root:(673,382),
    state 0x800, button 4, same_screen YES

ButtonPress event, serial 32, synthetic NO, window 0x2000001,
    root 0x139, subw 0x0, time 15265282, (82,90), root:(673,382),
    state 0x0, button 6, same_screen YES

ButtonRelease event, serial 32, synthetic NO, window 0x2000001,
    root 0x139, subw 0x0, time 15265282, (82,90), root:(673,382),
    state 0x0, button 6, same_screen YES

ButtonPress event, serial 32, synthetic NO, window 0x2000001,
    root 0x139, subw 0x0, time 15265282, (82,90), root:(673,382),
    state 0x0, button 4, same_screen YES

ButtonRelease event, serial 32, synthetic NO, window 0x2000001,
    root 0x139, subw 0x0, time 15265282, (82,90), root:(673,382),
    state 0x800, button 4, same_screen YES

ButtonPress event, serial 32, synthetic NO, window 0x2000001,
    root 0x139, subw 0x0, time 15265282, (82,90), root:(673,382),
    state 0x0, button 4, same_screen YES

ButtonRelease event, serial 32, synthetic NO, window 0x2000001,
    root 0x139, subw 0x0, time 15265282, (82,90), root:(673,382),
    state 0x800, button 4, same_screen YES
```
the button 6 events comes when i'm scrolling faster. 
fixes #58 