### PR TITLE
Add --no-timeout

### DIFF
--- a/man/unclutter-xfixes.man
+++ b/man/unclutter-xfixes.man
@@ -8,7 +8,7 @@ unclutter-xfixes - rewrite of unclutter using the X11-Xfixes extension
 
 == SYNOPSIS
 
-unclutter [*--timeout* _seconds_] [*--jitter* _radius_] [*--exclude-root*] [*--ignore-scrolling*] [*--ignore-buttons* _buttons_] [*--hide-on-touch*] [*--fork*|*-b*] [*--help*|*-h*] [*--version*|*-v*] [*--start-hidden*]
+unclutter [*--timeout* _seconds_] [*--no-timeout*] [*--jitter* _radius_] [*--exclude-root*] [*--ignore-scrolling*] [*--ignore-buttons* _buttons_] [*--hide-on-touch*] [*--fork*|*-b*] [*--help*|*-h*] [*--version*|*-v*] [*--start-hidden*]
 
 Compatibility arguments:
 
@@ -27,6 +27,10 @@ should work better with window managers and applications.
 *--timeout* _seconds_::
 Specifies the number of seconds after which the cursor should be hidden if
 it was neither moved nor any button was pressed. (Default: 5)
+
+*--no-timeout*::
+Disables the timeout mechanism entirely. Useful when used in combination with
+*--hide-on-touch*.
 
 *--jitter* _radius_::
 Ignore cursor movements if the cursor hasn't moved at least _radius_ pixels.

--- a/src/event.c
+++ b/src/event.c
@@ -2,7 +2,7 @@
 #include "all.h"
 
 static struct ev_loop *loop;
-static struct ev_timer *idle_watcher;
+static struct ev_timer *idle_watcher = NULL;
 static struct ev_io *x_watcher;
 static struct ev_check *x_check;
 
@@ -22,7 +22,11 @@ void event_init(void) {
 
     loop = EV_DEFAULT;
     event_init_x_loop();
-    event_init_timer();
+    
+    if (config.timeout >= 0.0) {
+        event_init_timer();
+    }
+
     ev_run(loop, 0);
 }
 
@@ -102,7 +106,10 @@ static void x_check_cb(EV_P_ ev_check *w, int revents) {
             /* We don't bother checking the exact event since we only select events that interest us. */
             cursor_show();
         }
-        ev_timer_again(loop, idle_watcher);
+
+        if (idle_watcher) {
+            ev_timer_again(loop, idle_watcher);
+        }
     }
 }
 

--- a/src/unclutter.c
+++ b/src/unclutter.c
@@ -96,6 +96,7 @@ static void parse_args(int argc, char *argv[]) {
 
         /* unclutter-xfixes options */
         { "timeout", required_argument, 0, 0 },
+        { "no-timeout", no_argument, 0, 0 },
         { "jitter", required_argument, 0, 0 },
         { "exclude-root", no_argument, 0, 0 },
         { "ignore-scrolling", no_argument, 0, 0 },
@@ -128,6 +129,9 @@ static void parse_args(int argc, char *argv[]) {
                     else
                         config.timeout = value_double;
 
+                    break;
+                } else if (OPT_NAME_IS("no-timeout")) {
+                    config.timeout = -1.0;
                     break;
                 } else if (OPT_NAME_IS("jitter")) {
                     value = parse_int(optarg);
@@ -204,7 +208,7 @@ static void parse_args(int argc, char *argv[]) {
 }
 
 static void print_usage(char *argv[]) {
-    fprintf(stderr, "Usage: %s [--timeout <n>] [--jitter <radius>] [--exclude-root] [--ignore-scrolling] [--ignore-buttons <buttons>] [--hide-on-touch] [-b|--fork] [-v|--version] [-h|--help] [--start-hidden]", argv[0]);
+    fprintf(stderr, "Usage: %s [--timeout <n>] [--no-timeout] [--jitter <radius>] [--exclude-root] [--ignore-scrolling] [--ignore-buttons <buttons>] [--hide-on-touch] [-b|--fork] [-v|--version] [-h|--help] [--start-hidden]", argv[0]);
     fprintf(stderr, "\n");
     exit(EXIT_FAILURE);
 }


### PR DESCRIPTION
Hello!

I recently found this tool to hide the mouse cursor if I'm using my notebooks touch screen.  And it works great!

However, my small gripe is that I need to set a timeout for the cursor to be hidden anyway.   Thus, I've added the `--no-timeout` option which allows the user to disable the timeout functionality entirely.

The defaults are unchanged, so existing users shouldn't notice much difference to their work flows :)

Cheers!